### PR TITLE
Custom "bubble up" error handlers for the CLI module

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,53 +44,6 @@ pub fn process_flags(args: std::env::Args) {
     }
 }
 
-/// Show help menu to the user.
-/// The help menu contains information on commands and flags, and what they do.
-pub fn help() {
-    println!(
-        "ReCTx :: Help Menu
-
-Usage: rectx <command> [options]
-
-Commands:
-  help          -> shows this menu
-  new [name]    -> creates a new project
-  run           -> runs the current project
-  build         -> builds the current project
-
-For more information visit the GitHub page: https://github.com/hrszpuk/rectx"
-    );
-    exit(0);
-}
-
-/// A specific help menu for the "new" command.
-/// Creating a new project using the new command: usage and explanation.
-pub fn help_new() {
-    println!(
-        "ReCTx :: Help Menu :: \"new\"
-
-Usage: rectx new project-name
-
-This command will create a new ReCT project with the name provided.
-The project will contain: /src/main.rs, README.md, and config.toml!
-
-For more information visit the GitHub page: https://github.com/hrszpuk/rectx"
-    )
-}
-
-pub fn help_unknown() {
-    println!(
-        "ReCTX :: Help Menu :: Unknown
-
-Usage: rectx <command> [options]
-
-The command you have entered does not seem to exist!
-Use \"rectx help\" for more information on the commands you can use.
-
-For more information visit the GitHub page: https://github.com/hrszpuk/rectx"
-    )
-}
-
 /// Creates a new project.
 /// This is called when the user calls the command "new".
 pub fn new_project(args: &Vec<String>) {
@@ -149,4 +102,90 @@ pub fn run_project() {
         }
     }
     exit(0);
+}
+
+/// Use cli::success when a successful process has taken place
+pub fn success(message: &String) {
+    println!(
+        "[SUCCESS] {}", message
+    );
+}
+
+/// Use cli::process when a process has began (logging)
+pub fn process(message: &string) {
+    println!(
+        "::: {}", message
+    );
+}
+
+/// use cli::issue when an issue is found, but can be recovered
+pub fn issue(message: &String) {
+    println!(
+        ":!: {}", message
+    );
+}
+
+/// Use cli::abort when an unrecoverable issue is found (exits the program)
+pub fn abort(message: &String) {
+    println!(
+        "!!! {}", message
+    );
+    println!(
+        "[ABORT] An unrecoverable error caused rectx to abort!"
+    );
+    exit(2);
+}
+
+/// Use cli::info when wanting to give the user non-specific information
+pub fn info(message: &String) {
+    println!(
+        "[INFO] {}", message
+    );
+}
+
+/// Show help menu to the user.
+/// The help menu contains information on commands and flags, and what they do.
+pub fn help() {
+    println!(
+        "ReCTx :: Help Menu
+
+Usage: rectx <command> [options]
+
+Commands:
+  help          -> shows this menu
+  new [name]    -> creates a new project
+  run           -> runs the current project
+  build         -> builds the current project
+
+For more information visit the GitHub page: https://github.com/hrszpuk/rectx"
+    );
+    exit(0);
+}
+
+/// A specific help menu for the "new" command.
+/// Creating a new project using the new command: usage and explanation.
+pub fn help_new() {
+    println!(
+        "ReCTx :: Help Menu :: \"new\"
+
+Usage: rectx new project-name
+
+This command will create a new ReCT project with the name provided.
+The project will contain: /src/main.rs, README.md, and config.toml!
+
+For more information visit the GitHub page: https://github.com/hrszpuk/rectx"
+    )
+}
+
+pub fn help_unknown() {
+    println!(
+        "ReCTX :: Help Menu :: Unknown
+
+Usage: rectx <command> [options]
+
+The command you have entered does not seem to exist!
+Use \"rectx help\" for more information on the commands you can use.
+
+For more information visit the GitHub page: https://github.com/hrszpuk/rectx"
+    )
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -9,6 +9,7 @@
 use std::{env, fs};
 use std::io::Write;
 use std::process::Command;
+use crate::cli;
 
 /// Generates a project directory containing the following:
 /// 1. README.md (with project name)
@@ -55,9 +56,10 @@ pub fn generate_project_executable() -> std::io::Result<()> {
 
     // Building file
     if paths.contains(&String::from("main.rct")) {
-        Command::new("rgoc")
+        let mut child = Command::new("rgoc")
             .arg("./src/main.rct")
             .spawn()?;
+        child.wait()?;
     } else {
         println!("rectx :: Could not find \"main.rct\" in \"/src\"!");
     }
@@ -70,7 +72,10 @@ pub fn generate_project_executable() -> std::io::Result<()> {
 pub fn generate_executable_and_run() -> std::io::Result<()>{
     generate_project_executable()?;
 
-    Command::new("./src/main")
+    cli::process(String::from("Running project executable"));
+
+    let mut child = Command::new("./src/main")
         .spawn()?;
+    child.wait()?;
     Ok(())
 }


### PR DESCRIPTION
## Issue
The issue this pull request attempts to resolve is the error messages produced by rectx.
Rectx will produce programmer errors (errors that are not easily readable to the average person unless they have knowledge of how Rust and ReCTx works) which even for ReCT programmers may be confusing.

Furthermore, it is possible for many different kinds of errors to be produced by the manager module even if most functions can return a `std::io::Error` through a `Result<T, E>` enum.

This pull request should close the issue described in #2.

## Solution
This pull request solves the issue above by refactoring the error system.
To begin with, the cli module now has a multitude of help functions now:
1. cli::abort(String): send a message to the user, and calls `panic!()` clearing the stack and aborting the entire program
2. cli::issue(String): when a recoverable error is found, message reports the issue to the user.
3. cli::info(String): this is just for sending non-specific information to the user
4. cli::process(String): for reporting the beginning of a process to the user
5. cli::success(Stirng): for reporting a successful result or process to the user

These helper functions are available to every module and allow for future modifications to the error system without major refactoring (like editing every println!.. etc).

The following cli module functions have had their error handling improved through detecting `ErrorKind` and reporting more specific error messages:
- `run_project()` (through `generate_executable_error_handle()`)
- `build_project()` (through `generate_executable_error_handle()`)
- `new_project()`