### PR TITLE
target/ and deps/ are now in [project] header (config.toml)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,8 @@ pub struct Project {
     pub version: String,
     pub authors: Vec<String>,
     pub remote: String,
+    pub target: String,
+    pub dependencies: String,
 }
 
 /// Stores information about compilation profiles
@@ -40,7 +42,6 @@ pub struct Profile {
     pub compiler_flags: Vec<String>,
     pub source_dir: String,
     pub source_main: String,
-    pub output_dir: String,
     pub output_name: String,
 }
 
@@ -55,13 +56,14 @@ impl Config {
                 version: String::from("0.1.0"),
                 authors: vec![],
                 remote: String::from(""),
+                target: "target".to_string(),
+                dependencies: "deps".to_string()
             },
             build: Profile {
                 compiler: String::from("rgoc"),
                 compiler_flags: vec!["-xx".to_string(), "-O".to_string()],
                 source_dir: String::from("src"),
                 source_main: String::from("main.rct"),
-                output_dir: String::from("target/build"),
                 output_name: name.clone(),
             },
             run: Profile {
@@ -69,7 +71,6 @@ impl Config {
                 compiler_flags: vec!["-xx".to_string()],
                 source_dir: String::from("src"),
                 source_main: String::from("main.rct"),
-                output_dir: String::from("target/run"),
                 output_name: name.clone(),
             }
         }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -46,9 +46,9 @@ pub fn generate_project_executable(run: bool) -> std::io::Result<()> {
     let conf = Config::load("config.toml");
     let mut profile = if run { conf.run } else { conf.build };
 
-    let main = format!("{}/{}", profile.source_dir, profile.source_main);
+    let main = format!("{}/{}", &profile.source_dir, &profile.source_main);
 
-    let dir_paths = fs::read_dir(profile.source_dir)?;
+    let dir_paths = fs::read_dir(&profile.source_dir)?;
 
     // Functional control flow magic
     let mut paths = dir_paths.filter_map(|entry| {
@@ -60,7 +60,7 @@ pub fn generate_project_executable(run: bool) -> std::io::Result<()> {
 
     // Building file
     if paths.contains(&profile.source_main) {
-        let mut child = Command::new(profile.compiler);
+        let mut child = Command::new(&profile.compiler);
         for flag in profile.compiler_flags {
             child.arg(&flag);
         }
@@ -71,8 +71,8 @@ pub fn generate_project_executable(run: bool) -> std::io::Result<()> {
     } else {
         cli::abort(format!(
             "Failed to find target \"{}\" in source directory \"{}\"!",
-            profile.source_main,
-            profile.source_dir,
+            &profile.source_main,
+            &profile.source_dir,
         ))
     }
 
@@ -80,7 +80,7 @@ pub fn generate_project_executable(run: bool) -> std::io::Result<()> {
         cli::process("Running project executable".to_string());
 
         let mut child = Command::new(
-            format!("./{}/{}", profile.output_dir, profile.output_name)
+            format!("./{}/{}", &conf.project.target, &profile.output_name)
         )
             .spawn()?;
         child.wait()?;


### PR DESCRIPTION
Moved where these properties are stored based on the fact I think it makes more sense for them to be overall for the project rather than based on build/run profiles.