### PR TITLE
Cross-platform support for Windows 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -83,7 +83,7 @@ impl Config {
         let toml_data = toml::to_string(&self)?;
 
         // Finally, we create the config.toml with our config data
-        fs::write(format!("{}/config.toml", path), toml_data)?;
+        fs::write(std::path::Path::new(path).join("config.toml"), toml_data)?;
         Ok(())
     }
 
@@ -94,7 +94,7 @@ impl Config {
         let metadata = fs::metadata(path);
         if !metadata.is_ok() {
             cli::abort(
-                String::from("Coudn't find a project configuration!")
+                String::from("Couldn't find a project configuration!")
             );
         } else if metadata.unwrap().is_dir() {
             cli::abort(


### PR DESCRIPTION
## Issue
The original issue was outlined by Mauro in #14. 
To put it simply, many of the paths used in the code were for Unix platforms only (using `/` between items in the path). 

## Solution
Instead of using `format!` to create paths with `/`, I've used `std::path::Path`. This should relieve any cross-platform issues related to paths. In some instances where `std::path::Path` was not viable, I have used `std::env::const::OS` and `format!` to create the correct path.