### PR TITLE
Templating parsing and generating is complete!

### DIFF
--- a/templates/command_statement.go
+++ b/templates/command_statement.go
@@ -1,0 +1,24 @@
+package templates
+
+import (
+	"os/exec"
+	"rectx/utilities"
+)
+
+type CommandStatement struct {
+	Command string
+}
+
+func NewCommandStatement(command string) *CommandStatement {
+	return &CommandStatement{
+		Command: command,
+	}
+}
+
+func (command *CommandStatement) Generate() {
+	cmd := exec.Command(command.Command)
+
+	err := cmd.Run()
+
+	utilities.Check(err)
+}

--- a/templates/file_statement.go
+++ b/templates/file_statement.go
@@ -1,0 +1,28 @@
+package templates
+
+import (
+	"os"
+	"rectx/utilities"
+)
+
+type FileStatement struct {
+	Name      string
+	SourceDir string
+	Content   string
+}
+
+func NewFileStatement(name string, sourceDir string, content string) *FileStatement {
+	return &FileStatement{
+		Name:      name,
+		SourceDir: sourceDir,
+		Content:   content,
+	}
+}
+
+func (file *FileStatement) Generate() {
+	f, err := os.Create(file.SourceDir + file.Name)
+	utilities.Check(err)
+
+	_, err = f.WriteString(file.Content)
+	utilities.Check(err)
+}

--- a/templates/folder_statement.go
+++ b/templates/folder_statement.go
@@ -1,0 +1,22 @@
+package templates
+
+import (
+	"os"
+	"rectx/utilities"
+)
+
+type FolderStatement struct {
+	Name      string
+	SourceDir string
+}
+
+func NewFolderStatement(name string, sourceDir string) *FolderStatement {
+	return &FolderStatement{
+		Name:      name,
+		SourceDir: sourceDir,
+	}
+}
+
+func (folder *FolderStatement) Generate() {
+	utilities.Check(os.Mkdir(folder.SourceDir+folder.Name, 0750))
+}

--- a/templates/lexer.go
+++ b/templates/lexer.go
@@ -1,0 +1,58 @@
+package templates
+
+import "fmt"
+
+func (tp *TemplateParser) Lex() {
+	for tp.index < len(tp.content) {
+		fmt.Printf("index: %d\n", tp.index)
+		if tp.current() == "#" {
+			for tp.index < len(tp.content) {
+				tp.index++
+				if tp.current() == "\n" {
+					break
+				}
+			}
+			tp.index++
+			continue
+		} else if tp.current() == "\"" {
+			buffer := ""
+			tp.index++
+			for tp.index < len(tp.content) && tp.current() != "\"" {
+				buffer += tp.current()
+				tp.index++
+			}
+			tp.index++
+			tp.tokens = append(tp.tokens, NewToken(buffer, STRING_TKN))
+		} else if tp.current() == "{" && tp.index+1 < len(tp.content) && tp.content[tp.index+1] == '%' {
+			buffer := ""
+			tp.index += 2
+			for tp.index < len(tp.content) {
+				buffer += tp.current()
+				tp.index++
+				if tp.current() == "%" && tp.index+1 < len(tp.content) && tp.content[tp.index+1] == '}' {
+					break
+				}
+			}
+			tp.tokens = append(tp.tokens, NewToken(buffer, CONTENT_TKN))
+		} else if tp.current() == " " || tp.current() == "\t" || tp.current() == "\n" {
+			tp.index++
+		} else {
+			buffer := ""
+			for tp.index < len(tp.content) && tp.current() != " " &&
+				tp.current() != "\t" && tp.current() != "\n" {
+				buffer += tp.current()
+				tp.index++
+			}
+			for _, keyword := range KEYWORDS {
+				if buffer == keyword {
+					tp.tokens = append(tp.tokens, NewToken(buffer, KEYWORD_TKN))
+				}
+			}
+			tp.index++
+		}
+	}
+}
+
+func (tp *TemplateParser) current() string {
+	return string(tp.content[tp.index])
+}

--- a/templates/parser.go
+++ b/templates/parser.go
@@ -40,7 +40,12 @@ func (tp *TemplateParser) Parse() []Statement {
 				tp.statements = append(tp.statements, tp.ParseCommand())
 			}
 		} else {
-			// TODO ERROR
+			token := tp.tokens[tp.index]
+			tp.index++
+			tp.statements = append(
+				tp.statements,
+				NewBadStatement(NewToken("", STRING_TKN), token),
+			)
 		}
 	}
 	return tp.statements
@@ -48,20 +53,20 @@ func (tp *TemplateParser) Parse() []Statement {
 
 func (tp *TemplateParser) ParseFolder() Statement {
 	tp.index++
-	var folderName string
+	var folderName = ""
 	if tp.tokens[tp.index].Kind == STRING_TKN {
 		folderName = tp.tokens[tp.index].Value
 		tp.index++
 	} else {
-		// TODO ERROR
+		token := tp.tokens[tp.index]
+		tp.index++
+		return NewBadStatement(NewToken("", STRING_TKN), token)
 	}
 
-	var sourceFolder string
+	var sourceFolder = ""
 	if tp.tokens[tp.index].Kind == STRING_TKN {
 		sourceFolder = tp.tokens[tp.index].Value
 		tp.index++
-	} else {
-		// TODO PATTERN ENDS... EXIT
 	}
 
 	return NewFolderStatement(folderName, sourceFolder)
@@ -69,28 +74,26 @@ func (tp *TemplateParser) ParseFolder() Statement {
 
 func (tp *TemplateParser) ParseFile() Statement {
 	tp.index++
-	var fileName string
+	var fileName = ""
 	if tp.tokens[tp.index].Kind == STRING_TKN {
 		fileName = tp.tokens[tp.index].Value
 		tp.index++
 	} else {
-		// TODO ERROR
+		token := tp.tokens[tp.index]
+		tp.index++
+		return NewBadStatement(NewToken("", STRING_TKN), token)
 	}
 
-	var sourceFolder string
+	var sourceFolder = ""
 	if tp.tokens[tp.index].Kind == STRING_TKN {
 		sourceFolder = tp.tokens[tp.index].Value
 		tp.index++
-	} else {
-		// TODO PATTERN ENDS... EXIT
 	}
 
-	var contentBlock string
+	var contentBlock = ""
 	if tp.tokens[tp.index].Kind == CONTENT_TKN {
 		contentBlock = tp.tokens[tp.index].Value
 		tp.index++
-	} else {
-		// TODO PATTERN ENDS... EXIT (check if keyword next though)
 	}
 
 	return NewFileStatement(fileName, sourceFolder, contentBlock)
@@ -103,7 +106,9 @@ func (tp *TemplateParser) ParseCommand() Statement {
 		command = tp.tokens[tp.index].Value
 		tp.index++
 	} else {
-		// TODO ERROR
+		token := tp.tokens[tp.index]
+		tp.index++
+		return NewBadStatement(NewToken("", STRING_TKN), token)
 	}
 
 	return NewCommandStatement(command)

--- a/templates/parser.go
+++ b/templates/parser.go
@@ -9,11 +9,12 @@ var KEYWORDS = []string{
 }
 
 type TemplateParser struct {
-	content string
-	tokens  []*Token
-	index   int
-	errors  []string
-	token   *Token
+	content    string
+	tokens     []*Token
+	index      int
+	errors     []string
+	token      *Token
+	statements []Statement
 }
 
 func NewTemplateParser(content string) *TemplateParser {
@@ -24,17 +25,8 @@ func NewTemplateParser(content string) *TemplateParser {
 	}
 }
 
-func (tp *TemplateParser) Parse() {
+func (tp *TemplateParser) Parse() []*Statement {
 	tp.Lex()
-	/* Patterns:
-	FOLDER STRING
-	FOLDER STRING STRING
-	FILE STRING
-	FILE STRING STRING
-	FILE STRING STRING BLOCK
-	FILE STRING BLOCK
-	COMMAND STRING
-	*/
 	tp.index = 0
 	tp.token = tp.tokens[tp.index]
 
@@ -71,7 +63,8 @@ func (tp *TemplateParser) ParseFolder() {
 		// TODO PATTERN ENDS... EXIT
 	}
 
-	// TODO BUILD FOLDER STATEMENT
+	stmt := NewFolderStatement(folderName, sourceFolder)
+	tp.statements = append(tp.statements, stmt)
 }
 
 func (tp *TemplateParser) ParseFile() {
@@ -100,7 +93,8 @@ func (tp *TemplateParser) ParseFile() {
 		// TODO PATTERN ENDS... EXIT (check if keyword next though)
 	}
 
-	// TODO BUILD FILE STATEMENT
+	stmt := NewFileStatement(fileName, sourceFolder, contentBlock)
+	tp.statements = append(tp.statements, stmt)
 }
 
 func (tp *TemplateParser) ParseCommand() {
@@ -113,5 +107,6 @@ func (tp *TemplateParser) ParseCommand() {
 		// TODO ERROR
 	}
 
-	// TODO: BUILD COMMAND STATEMENT
+	stmt := NewCommandStatement(command)
+	tp.statements = append(tp.statements, stmt)
 }

--- a/templates/parser.go
+++ b/templates/parser.go
@@ -48,7 +48,7 @@ func (tp *TemplateParser) Parse() {
 				tp.ParseCommand()
 			}
 		} else {
-			// ERROR
+			// TODO ERROR
 		}
 	}
 }
@@ -60,7 +60,7 @@ func (tp *TemplateParser) ParseFolder() {
 		folderName = tp.tokens[tp.index].Value
 		tp.index++
 	} else {
-		// ERROR
+		// TODO ERROR
 	}
 
 	var sourceFolder string
@@ -68,16 +68,50 @@ func (tp *TemplateParser) ParseFolder() {
 		sourceFolder = tp.tokens[tp.index].Value
 		tp.index++
 	} else {
-		// PATTERN ENDS... EXIT (check if keyword though)
+		// TODO PATTERN ENDS... EXIT
 	}
 
-	// BUILD FOLDER STATEMENT
+	// TODO BUILD FOLDER STATEMENT
 }
 
 func (tp *TemplateParser) ParseFile() {
+	tp.index++
+	var fileName string
+	if tp.tokens[tp.index].Kind == STRING_TKN {
+		fileName = tp.tokens[tp.index].Value
+		tp.index++
+	} else {
+		// TODO ERROR
+	}
 
+	var sourceFolder string
+	if tp.tokens[tp.index].Kind == STRING_TKN {
+		sourceFolder = tp.tokens[tp.index].Value
+		tp.index++
+	} else {
+		// TODO PATTERN ENDS... EXIT
+	}
+
+	var contentBlock string
+	if tp.tokens[tp.index].Kind == CONTENT_TKN {
+		contentBlock = tp.tokens[tp.index].Value
+		tp.index++
+	} else {
+		// TODO PATTERN ENDS... EXIT (check if keyword next though)
+	}
+
+	// TODO BUILD FILE STATEMENT
 }
 
 func (tp *TemplateParser) ParseCommand() {
+	tp.index++
+	var command string
+	if tp.tokens[tp.index].Kind == STRING_TKN {
+		command = tp.tokens[tp.index].Value
+		tp.index++
+	} else {
+		// TODO ERROR
+	}
 
+	// TODO: BUILD COMMAND STATEMENT
 }

--- a/templates/parser.go
+++ b/templates/parser.go
@@ -25,7 +25,7 @@ func NewTemplateParser(content string) *TemplateParser {
 	}
 }
 
-func (tp *TemplateParser) Parse() []*Statement {
+func (tp *TemplateParser) Parse() []Statement {
 	tp.Lex()
 	tp.index = 0
 	tp.token = tp.tokens[tp.index]
@@ -33,19 +33,20 @@ func (tp *TemplateParser) Parse() []*Statement {
 	for tp.index < len(tp.tokens) {
 		if tp.token.Kind == KEYWORD_TKN {
 			if strings.ToLower(tp.token.Value) == "folder" {
-				tp.ParseFolder()
+				tp.statements = append(tp.statements, tp.ParseFolder())
 			} else if strings.ToLower(tp.token.Value) == "file" {
-				tp.ParseFile()
+				tp.statements = append(tp.statements, tp.ParseFile())
 			} else if strings.ToLower(tp.token.Value) == "command" {
-				tp.ParseCommand()
+				tp.statements = append(tp.statements, tp.ParseCommand())
 			}
 		} else {
 			// TODO ERROR
 		}
 	}
+	return tp.statements
 }
 
-func (tp *TemplateParser) ParseFolder() {
+func (tp *TemplateParser) ParseFolder() Statement {
 	tp.index++
 	var folderName string
 	if tp.tokens[tp.index].Kind == STRING_TKN {
@@ -63,11 +64,10 @@ func (tp *TemplateParser) ParseFolder() {
 		// TODO PATTERN ENDS... EXIT
 	}
 
-	stmt := NewFolderStatement(folderName, sourceFolder)
-	tp.statements = append(tp.statements, stmt)
+	return NewFolderStatement(folderName, sourceFolder)
 }
 
-func (tp *TemplateParser) ParseFile() {
+func (tp *TemplateParser) ParseFile() Statement {
 	tp.index++
 	var fileName string
 	if tp.tokens[tp.index].Kind == STRING_TKN {
@@ -93,11 +93,10 @@ func (tp *TemplateParser) ParseFile() {
 		// TODO PATTERN ENDS... EXIT (check if keyword next though)
 	}
 
-	stmt := NewFileStatement(fileName, sourceFolder, contentBlock)
-	tp.statements = append(tp.statements, stmt)
+	return NewFileStatement(fileName, sourceFolder, contentBlock)
 }
 
-func (tp *TemplateParser) ParseCommand() {
+func (tp *TemplateParser) ParseCommand() Statement {
 	tp.index++
 	var command string
 	if tp.tokens[tp.index].Kind == STRING_TKN {
@@ -107,6 +106,5 @@ func (tp *TemplateParser) ParseCommand() {
 		// TODO ERROR
 	}
 
-	stmt := NewCommandStatement(command)
-	tp.statements = append(tp.statements, stmt)
+	return NewCommandStatement(command)
 }

--- a/templates/statement.go
+++ b/templates/statement.go
@@ -1,0 +1,5 @@
+package templates
+
+type Statement interface {
+	Generate()
+}

--- a/templates/statement.go
+++ b/templates/statement.go
@@ -1,5 +1,28 @@
 package templates
 
+import "fmt"
+
 type Statement interface {
 	Generate()
+}
+
+type BadStatement struct {
+	expectedToken *Token
+	tokenFound    *Token
+}
+
+func NewBadStatement(expected, found *Token) *BadStatement {
+	return &BadStatement{
+		expectedToken: expected,
+		tokenFound:    found,
+	}
+}
+
+func (bs *BadStatement) Generate() {
+	fmt.Printf(
+		"ERROR: Expected Token of type \"%s\" but found Token of type \"%s\" with values of \"%s\"!\n",
+		bs.expectedToken.Kind,
+		bs.tokenFound.Kind,
+		bs.tokenFound.Value,
+	)
 }


### PR DESCRIPTION
## Template parsing and generating
Template files can now be parsed and the statements created can be used to generate the project structure. This can now be used by the project manager to generate a project structure from a selected template.

More work does need to be made on templates in the future, but for now this solution works.
Future work on templates includes: `template test` subcommand to allow people to test custom templates, template errors need line & column information, and a template binder to check if a source folder has been created prior to the placing of files inside.

## Related Issues/Pull Requests
- #26 