### PR TITLE
Template and license validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,11 +55,15 @@ func ValidateConfig() {
 	if _, err := os.Stat(home + "/templates"); os.IsNotExist(err) {
 		// if ~/.rectx/templates generation is handled by the templates module
 		GenerateTemplates()
+	} else {
+		ValidateTemplates()
 	}
 
 	if _, err := os.Stat(home + "/licenses"); os.IsNotExist(err) {
 		// if ~/.rectx/templates generation is handled by the templates module
 		GenerateLicenses()
+	} else {
+		ValidateLicenses()
 	}
 }
 

--- a/config/licenses.go
+++ b/config/licenses.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"rectx/utilities"
 )
@@ -18,11 +19,34 @@ var LICENSES = [...]string{
 func GenerateLicenses() {
 	utilities.Check(os.Mkdir(utilities.GetRectxPath()+"/licenses", os.ModePerm))
 
+	DownloadLicenses(utilities.GetRectxPath() + "/licenses/")
+	ValidateLicenses()
+}
+
+func DownloadLicenses(path string) {
 	for _, license := range LICENSES {
 		utilities.DownloadFile(
 			"https://hrszpuk.github.io/rectx/licenses/"+license,
-			utilities.GetRectxPath()+"/licenses/"+license,
+			path+license,
 		)
 	}
-	// TODO validate licenses/ has license files in it
+}
+
+func ValidateLicenses() {
+	dir, err := os.ReadDir(utilities.GetRectxPath() + "/licenses")
+	utilities.Check(err)
+
+	if len(dir) < 1 {
+		DownloadLicenses(utilities.GetRectxPath() + "/licenses/")
+		dir, err = os.ReadDir(utilities.GetRectxPath() + "/licenses")
+		utilities.Check(err)
+
+		if len(dir) < 1 {
+			fmt.Println("ERROR: Could not download licenses for an unknown reason!")
+		}
+	}
+
+	if len(dir) < 3 {
+		fmt.Printf("ERROR: Expected at least %d licenses but only found %d! You may want to regenerate the template files using \"rectx config regenerate --licenses\"!\n", len(TEMPLATE), len(dir))
+	}
 }

--- a/config/templates.go
+++ b/config/templates.go
@@ -39,12 +39,11 @@ func ValidateTemplates() {
 		utilities.Check(err)
 
 		if len(dir) < 1 {
-			fmt.Println("Could not download templates for an unknown reason!")
-			os.Exit(1)
+			fmt.Println("ERROR: Could not download templates for an unknown reason!")
 		}
 	}
 
 	if len(dir) < 3 {
-		fmt.Printf("Expected at least %d templates but only found %d! You may want to regenerate the template files using rectx template regenerate!\n", len(TEMPLATE), len(dir))
+		fmt.Printf("ERROR: Expected at least %d templates but only found %d! You may want to regenerate the template files using \"rectx config regenerate --templates\"!\n", len(TEMPLATE), len(dir))
 	}
 }

--- a/config/templates.go
+++ b/config/templates.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"rectx/utilities"
 )
@@ -14,12 +15,36 @@ var TEMPLATE = [...]string{
 func GenerateTemplates() {
 	utilities.Check(os.Mkdir(utilities.GetRectxPath()+"/templates", os.ModePerm))
 
+	DownloadTemplates(utilities.GetRectxPath() + "/templates/")
+	ValidateTemplates()
+}
+
+func DownloadTemplates(path string) {
 	domain := "https://hrszpuk.github.io/rectx/templates/"
 	for _, name := range TEMPLATE {
 		utilities.DownloadFile(
 			domain+name+".rectx.template",
-			utilities.GetRectxPath()+"/templates/"+name+".rectx.template",
+			path+name+".rectx.template",
 		)
 	}
-	// TODO validate /templates has template files in it
+}
+
+func ValidateTemplates() {
+	dir, err := os.ReadDir(utilities.GetRectxPath() + "/templates")
+	utilities.Check(err)
+
+	if len(dir) < 1 {
+		DownloadTemplates(utilities.GetRectxPath() + "/templates/")
+		dir, err = os.ReadDir(utilities.GetRectxPath() + "/templates")
+		utilities.Check(err)
+
+		if len(dir) < 1 {
+			fmt.Println("Could not download templates for an unknown reason!")
+			os.Exit(1)
+		}
+	}
+
+	if len(dir) < 3 {
+		fmt.Printf("Expected at least %d templates but only found %d! You may want to regenerate the template files using rectx template regenerate!\n", len(TEMPLATE), len(dir))
+	}
 }


### PR DESCRIPTION
This pull request adds additional validation to the `templates/` and `licenses/` directories.
This means if any templates or licenses are missing then rectx will warn the user about the issue and suggest a command to re-download the missing files.

## Related Issue
- #44 