### PR TITLE
Add `rectx template list` lists all the templates in the template directory and suggest regenerating them if there are none

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -7,22 +7,22 @@ import (
 
 var (
 	// rectx new [optional]
-	newCmd      = flag.NewFlagSet("new", flag.ExitOnError)
-	projectName string // -n --name
-	author      string // -a --author
-	template    string // -t --template
-	path        string // -p --path
-	license     string // -l --license
-	version     string // -v --version
-	noPrompt    bool   // -np --no-prompt
+	newCmd          = flag.NewFlagSet("new", flag.ExitOnError)
+	projectNameFlag string // -n --name
+	authorFlag      string // -a --author
+	templateFlag    string // -t --template
+	pathFlag        string // -p --path
+	licenseFlag     string // -l --license
+	versionFlag     string // -v --version
+	noPromptFlag    bool   // -np --no-prompt
 
 	// rectx build [optional]
-	buildCmd     = flag.NewFlagSet("build", flag.ExitOnError)
-	buildProfile string // -p --profile
+	buildCmd         = flag.NewFlagSet("build", flag.ExitOnError)
+	buildProfileFlag string // -p --profile
 
 	// rectx run [optional]
-	runCmd     = flag.NewFlagSet("run", flag.ExitOnError)
-	runProfile string // -p --profile
+	runCmd         = flag.NewFlagSet("run", flag.ExitOnError)
+	runProfileFlag string // -p --profile
 
 	// rectx template <subcommand> [optional]
 	templateCmd               = flag.NewFlagSet("template", flag.ExitOnError)
@@ -50,12 +50,12 @@ var (
 	configSubcommandArguments = []string{
 		"(None)", "(None)", "key-name", "key-name new-key-value",
 	}
-	configFile bool // -c --config
-	templates  bool // -t --templates
-	licenses   bool // -l --licenses
-	all        bool // -a --all
+	configFileFlag bool // -c --config
+	templatesFlag  bool // -t --templates
+	licensesFlag   bool // -l --licenses
+	allFlag        bool // -a --all
 
-	help bool
+	helpFlag bool
 
 	CMDS = [...]*flag.FlagSet{newCmd, buildCmd, runCmd, templateCmd, configCmd}
 
@@ -70,33 +70,33 @@ func initFlags() {
 	initConfigFlags()
 
 	for _, cmd := range CMDS {
-		cmd.BoolVar(&help, "help", false, "Shows a specific help message for the command used.")
+		cmd.BoolVar(&helpFlag, "help", false, "Shows a specific help message for the command used.")
 	}
 }
 
 func initNewFlags() {
-	newCmd.StringVar(&projectName, "name", "Untitled", "Specify what you want your project to be called.")
-	newCmd.StringVar(&author, "author", "", "Specify who is creating the project.")
-	newCmd.StringVar(&template, "template", "default", "Specify how you want the project structure to look.")
-	newCmd.StringVar(&path, "path", "Untitled", "Specify where to put the project.")
-	newCmd.StringVar(&license, "license", "", "Specify which license you want your project to use.")
-	newCmd.StringVar(&version, "version", "0.1.0", "Specify what version to start the project at.")
-	newCmd.BoolVar(&noPrompt, "noPrompt", false, "Don't show the project prompt (generate based off defaults and provided flags).")
+	newCmd.StringVar(&projectNameFlag, "name", "Untitled", "Specify what you want your project to be called.")
+	newCmd.StringVar(&authorFlag, "author", "", "Specify who is creating the project.")
+	newCmd.StringVar(&templateFlag, "template", "default", "Specify how you want the project structure to look.")
+	newCmd.StringVar(&pathFlag, "path", "Untitled", "Specify where to put the project.")
+	newCmd.StringVar(&licenseFlag, "license", "", "Specify which license you want your project to use.")
+	newCmd.StringVar(&versionFlag, "version", "0.1.0", "Specify what version to start the project at.")
+	newCmd.BoolVar(&noPromptFlag, "noPrompt", false, "Don't show the project prompt (generate based off defaults and provided flags).")
 }
 
 func initConfigFlags() {
-	configCmd.BoolVar(&configFile, "config", false, "Specifies the rectx config file specifically.")
-	configCmd.BoolVar(&templates, "templates", false, "Specifies the rectx templates specifically.")
-	configCmd.BoolVar(&licenses, "licenses", false, "Specifies the rectx licenses specifically.")
-	configCmd.BoolVar(&all, "all", false, "Specifically validate/regenerate the entire rectx config directory.")
+	configCmd.BoolVar(&configFileFlag, "config", false, "Specifies the rectx config file specifically.")
+	configCmd.BoolVar(&templatesFlag, "templates", false, "Specifies the rectx templates specifically.")
+	configCmd.BoolVar(&licensesFlag, "licenses", false, "Specifies the rectx licenses specifically.")
+	configCmd.BoolVar(&allFlag, "all", false, "Specifically validate/regenerate the entire rectx config directory.")
 }
 
 func initBuildFlags() {
-	buildCmd.StringVar(&buildProfile, "profile", "", "Specify a custom build profile for the project (must be declared in the project.rectx).")
+	buildCmd.StringVar(&buildProfileFlag, "profile", "", "Specify a custom build profile for the project (must be declared in the project.rectx).")
 }
 
 func initRunFlags() {
-	runCmd.StringVar(&runProfile, "profile", "", "Specify a custom run profile for the project (must be declared in the project.rectx).")
+	runCmd.StringVar(&runProfileFlag, "profile", "", "Specify a custom run profile for the project (must be declared in the project.rectx).")
 }
 
 func ShowUsage(command string, showSubcommands bool) {
@@ -141,7 +141,7 @@ func ShowNewHelpMenu() {
 		"\n  [details]\n  Used to create a new project! \n  This command will prompt you questions about your project" +
 			"and then generate all the project files you need to get started." +
 			"\n  Optionally, you can pass flags such as --name=\"borgor\" to quickly assign values without the prompt!" +
-			"\n  You can also add default values for author, license, template, which will make the prompt much faster to fill out!\n\n")
+			"\n  You can also add default values for authorFlag, license, template, which will make the prompt much faster to fill out!\n\n")
 	fmt.Println("  [flags]")
 	newCmd.PrintDefaults()
 }
@@ -197,7 +197,7 @@ func handleParseErrorAndHelpFlag(command *flag.FlagSet, err error, helpMenu func
 		name := command.Name()
 		fmt.Println("An unexpected error occurred during flag parsing!")
 		fmt.Printf("Please try \"rectx %s --help\" for more information on the %s command!\n", name, name)
-	} else if help {
+	} else if helpFlag {
 		helpMenu()
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"rectx/project_manager"
+	"rectx/templates"
 )
 
 func main() {
@@ -26,6 +28,14 @@ func main() {
 		project_manager.Run()
 	case "template":
 		handleParseErrorAndHelpFlag(templateCmd, templateCmd.Parse(os.Args[2:]), ShowTemplateHelpMenu)
+		if len(os.Args) == 3 {
+			if os.Args[2] == "list" {
+				fmt.Println("Listing all templates found:")
+				for i, files := range templates.ListTemplates() {
+					fmt.Printf("%d. %s\n", i+1, files)
+				}
+			}
+		}
 	case "config":
 		handleParseErrorAndHelpFlag(configCmd, configCmd.Parse(os.Args[2:]), ShowConfigHelpMenu)
 	case "help":

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ func main() {
 	case "run":
 		handleParseErrorAndHelpFlag(runCmd, runCmd.Parse(os.Args[2:]), ShowRunHelpMenu)
 		project_manager.Run()
+	case "templates":
+		fallthrough
 	case "template":
 		handleParseErrorAndHelpFlag(templateCmd, templateCmd.Parse(os.Args[2:]), ShowTemplateHelpMenu)
 		if len(os.Args) == 3 {

--- a/templates/lexer.go
+++ b/templates/lexer.go
@@ -55,7 +55,7 @@ func (tp *TemplateParser) Lex() {
 			}
 			for _, keyword := range KEYWORDS {
 				if buffer == keyword {
-					tp.tokens = append(tp.tokens, NewToken(buffer, KEYWORD_TKN))
+					tp.tokens = append(tp.tokens, NewToken(buffer, KEYWORD_TKN, tp.line, tp.column))
 				}
 			}
 			tp.index++

--- a/templates/parser.go
+++ b/templates/parser.go
@@ -45,7 +45,7 @@ func (tp *TemplateParser) Parse() []Statement {
 			tp.index++
 			tp.statements = append(
 				tp.statements,
-				NewBadStatement(NewToken("", KEYWORD_TKN), token),
+				NewBadStatement(NewToken("", KEYWORD_TKN, token.line, token.column), token),
 			)
 		}
 	}
@@ -61,7 +61,7 @@ func (tp *TemplateParser) ParseFolder() Statement {
 	} else {
 		token := tp.tokens[tp.index]
 		tp.index++
-		return NewBadStatement(NewToken("", STRING_TKN), token)
+		return NewBadStatement(NewToken("", STRING_TKN, token.line, token.column), token)
 	}
 
 	var sourceFolder = ""
@@ -82,7 +82,7 @@ func (tp *TemplateParser) ParseFile() Statement {
 	} else {
 		token := tp.tokens[tp.index]
 		tp.index++
-		return NewBadStatement(NewToken("", STRING_TKN), token)
+		return NewBadStatement(NewToken("", STRING_TKN, token.line, token.column), token)
 	}
 
 	var sourceFolder = ""
@@ -109,7 +109,7 @@ func (tp *TemplateParser) ParseCommand() Statement {
 	} else {
 		token := tp.tokens[tp.index]
 		tp.index++
-		return NewBadStatement(NewToken("", STRING_TKN), token)
+		return NewBadStatement(NewToken("", STRING_TKN, token.line, token.column), token)
 	}
 
 	return NewCommandStatement(command)

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -26,3 +26,16 @@ func FetchTemplates() []string {
 
 	return templateList
 }
+
+func ListTemplates() []string {
+	dir, err := os.ReadDir(utilities.GetRectxPath() + "/templates")
+	utilities.Check(err)
+
+	var list []string
+
+	for _, entry := range dir {
+		list = append(list, entry.Name())
+	}
+
+	return list
+}


### PR DESCRIPTION
This pull request adds the command `rectx template list` which lists all the templates installed. It also renames several flags in `cli.go` because they were interfering with package names and general logic. Each flag has been given the suffix "Flag". This commit also adds the alias `templates` to the command `template` because omg why didn't I think of this sooner.

## Changelog
- Added "Flag" suffix to all flags in `cli.go`
- Added `templates` alias to command `template`
- Added subcommand `list` for `rect template` (`rectx template list`)

## Related Issues/PR
- Closes #51 