### PR TITLE
Fixed `rectx template add <template>` error message recognising non-existent files

### DIFF
--- a/config/templates.go
+++ b/config/templates.go
@@ -61,26 +61,25 @@ func AddTemplate(path string) {
 	} else if os.IsPermission(err) {
 		utilities.Check(err, true, "Attempted to load template but failed due to a lack of permissions.")
 	} else {
-		utilities.Check(err, true, "Attempted to load template but failed for unkown reasons.")
+		utilities.Check(err, true, "Attempted to load template but failed for an unknown reason.")
 	}
 
 	ValidateTemplates()
 	pathSplit := strings.Split(path, "/")
 
 	file, err := os.Create(utilities.GetRectxPath() + "/templates/" + pathSplit[len(pathSplit)-1])
-	defer file.Close()
 
 	if os.IsPermission(err) {
 		utilities.Check(err, true, "Attempted to create internal template file but failed due to a lack of permissions.")
 	} else {
-		utilities.Check(err, true, "Attempted to create internal template file but failed for unkown reasons.")
+		utilities.Check(err, true, "Attempted to create internal template file but failed for unknown reasons.")
 	}
 
 	_, err = file.WriteString(string(bytes))
 	if os.IsPermission(err) {
-		utilities.Check(err, true, "Attempted to write to internal tempalte file but failed due to a lack of permissions.")
+		utilities.Check(err, true, "Attempted to write to internal template file but failed due to a lack of permissions.")
 	} else {
-		utilities.Check(err, true, "Attempted to write to internal tempalte file but failed for unkown reasons.")
+		utilities.Check(err, true, "Attempted to write to internal template file but failed for unknown reasons.")
 	}
 
 	fmt.Printf("Added new template called \"%s\"!", pathSplit[len(pathSplit)-1])
@@ -88,6 +87,8 @@ func AddTemplate(path string) {
 		"If you want to rename this template use: rectx template rename <name> <newName>",
 		"For more information on templates please use rectx template --help",
 	)
+
+	utilities.Check(file.Close(), false, "Was unable to close file!")
 }
 
 // rectx template rename <templateName> <newTemplateName>

--- a/config/templates.go
+++ b/config/templates.go
@@ -47,9 +47,12 @@ func ValidateTemplates() {
 
 // rectx template add <path/to/template>
 func AddTemplate(path string) {
-	if !strings.HasSuffix(path, ".rectx.template") {
-		fmt.Printf("Unable to add template because \"%s\" is not a rectx template file!", path)
-		os.Exit(1)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		msg := fmt.Sprintf("Unable to add template because \"%s\" does not exist!", path)
+		utilities.Check(err, true, msg)
+	} else if !strings.HasSuffix(path, ".rectx.template") {
+		msg := fmt.Sprintf("Unable to add template because \"%s\" is not a rectx template file!", path)
+		utilities.Check(err, true, msg)
 	}
 
 	bytes, err := os.ReadFile(path)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	case "run":
 		handleParseErrorAndHelpFlag(runCmd, runCmd.Parse(os.Args[2:]), ShowRunHelpMenu)
 		project_manager.Run()
-	
+
 	// rectx template|templates
 	// I allow both "templates" and "template" because both go well with the subcommands and I kept putting the wrong one.
 	case "templates":
@@ -53,13 +53,7 @@ func main() {
 		// Although this is a template subcommand, it uses the config package because it manages the ~/.rectx config directory where the templates are stored.
 		case "add":
 			EnsureArguments(4, "template add")
-			// TODO Maybe check if file exists first?
-			if !strings.HasSuffix(os.Args[3], ".rectx.template") {
-				fmt.Printf("Whoops \"%s\" isn't a .rectx.template file!\n", os.Args[3])
-				os.Exit(1)
-			} else {
-				config.AddTemplate(os.Args[3])
-			}
+			config.AddTemplate(os.Args[3])
 
 		// `rectx template test <template>` parses and generates using a template file in a temporary directory.
 		// This command was designed to allow you to test for errors in a template file. Errors are reported to the command line.
@@ -89,7 +83,7 @@ func main() {
 			fmt.Printf("Unknown subcommand \"%s\"! Maybe try rectx templates --help for a list of subcommands...\n", os.Args[2])
 		}
 
-	// rectx config 
+	// rectx config
 	// TODO I should probably start this before it's too late - Tokorv
 	case "config":
 		handleParseErrorAndHelpFlag(configCmd, configCmd.Parse(os.Args[2:]), ShowConfigHelpMenu)
@@ -105,7 +99,7 @@ func main() {
 	}
 }
 
-// This function is used to check if the required number of arguments is met. 
+// This function is used to check if the required number of arguments is met.
 // If so, the function will do nothing, otherwise it will display an error message, and a usage for the command provided.
 // If only a command that requires a subcommand is supplied (via command argument) then a <subcommand> will be displayed
 // in the usage message. Otherwise, only <arg> symbols will be displayed.


### PR DESCRIPTION
## Fixes
- Removed file existence checks in `main.go`
- Added file existence checks in function `AddTemplate` in package `config/template.go`
- Added `utilities.Check` error messaging instead of printing then exiting
- Also fixed typos in error messages in function `AddTemplate`

## Related Issues/PR
- Close #63 