### PR TITLE
LICENSE file generation during project generation with License meta-variables

### DIFF
--- a/config/licenses.go
+++ b/config/licenses.go
@@ -2,18 +2,9 @@ package config
 
 import (
 	"os"
+	"rectx/licenses"
 	"rectx/utilities"
 )
-
-var LICENSES = [...]string{
-	"Apache_License_2.0",
-	"Boost_Software_License",
-	"GNU_AGPLv3",
-	"GNU_GPL3",
-	"GNU_LGPLv3",
-	"MIT_License",
-	"Mozilla_Public_License_2.0",
-}
 
 func GenerateLicenses() {
 	if err := os.Mkdir(utilities.GetRectxPath()+"/licenses", os.ModePerm); os.IsPermission(err) {
@@ -22,17 +13,8 @@ func GenerateLicenses() {
 		utilities.Check(err, true, "Attempted to create licenses/ but failed for an unknown reason.")
 	}
 
-	DownloadLicenses(utilities.GetRectxPath() + "/licenses/")
+	licenses.DownloadLicenses(utilities.GetRectxPath() + "/licenses/")
 	ValidateLicenses()
-}
-
-func DownloadLicenses(path string) {
-	for _, license := range LICENSES {
-		utilities.DownloadFile(
-			utilities.GetRectxDownloadSource()+"/licenses/"+license,
-			path+license,
-		)
-	}
 }
 
 func ValidateLicenses() {
@@ -40,7 +22,7 @@ func ValidateLicenses() {
 	utilities.ErrCheckReadDir(err, "licenses/", GenerateLicenses)
 
 	if len(dir) < 1 {
-		DownloadLicenses(utilities.GetRectxPath() + "/licenses/")
+		licenses.DownloadLicenses(utilities.GetRectxPath() + "/licenses/")
 		dir, err = os.ReadDir(utilities.GetRectxPath() + "/licenses")
 		utilities.ErrCheckReadDir(err, "licenses/", GenerateLicenses)
 	}

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,1 @@
+# licenses

--- a/licenses/generator.go
+++ b/licenses/generator.go
@@ -10,6 +10,7 @@ func GenerateLicense(license string, variables map[string]string) {
 	bytes, err := os.ReadFile(utilities.GetRectxPath() + "/licenses/" + license)
 	utilities.Check(err, true, "Failed to fetch license file specified!")
 	content := string(bytes)
+
 	content = metavariables.NewParser(content, variables).Parse()
 
 	file, err := os.Create(variables["%PROJECT_NAME%"] + "/" + "LICENSE")

--- a/licenses/generator.go
+++ b/licenses/generator.go
@@ -1,0 +1,1 @@
+package licenses

--- a/licenses/generator.go
+++ b/licenses/generator.go
@@ -2,13 +2,11 @@ package licenses
 
 import (
 	"os"
-	"rectx/config"
 	"rectx/metavariables"
 	"rectx/utilities"
 )
 
 func GenerateLicense(license string, variables map[string]string) {
-	config.ValidateLicenses()
 	bytes, err := os.ReadFile(utilities.GetRectxPath() + "/licenses/" + license)
 	utilities.Check(err, true, "Failed to fetch license file specified!")
 	content := string(bytes)

--- a/licenses/generator.go
+++ b/licenses/generator.go
@@ -1,5 +1,23 @@
 package licenses
 
-func GenerateLicense(license string) {
+import (
+	"os"
+	"rectx/config"
+	"rectx/metavariables"
+	"rectx/utilities"
+)
 
+func GenerateLicense(license string, variables map[string]string) {
+	config.ValidateLicenses()
+	bytes, err := os.ReadFile(utilities.GetRectxPath() + "/licenses/" + license)
+	utilities.Check(err, true, "Failed to fetch license file specified!")
+	content := string(bytes)
+	content = metavariables.NewParser(content, variables).Parse()
+
+	file, err := os.Create(variables["%PROJECT_NAME%"] + "/" + "LICENSE")
+	utilities.Check(err, false, "Failed to create LICENSE file for project!")
+	_, err = file.WriteString(content)
+	utilities.Check(err, false, "Attempted to write content to LICENSE file but failed.")
+	err = file.Close()
+	utilities.Check(err, false, "Failed to close file!")
 }

--- a/licenses/generator.go
+++ b/licenses/generator.go
@@ -1,1 +1,5 @@
 package licenses
+
+func GenerateLicense(license string) {
+
+}

--- a/licenses/manager.go
+++ b/licenses/manager.go
@@ -10,6 +10,7 @@ var LICENSES = []string{
 	"GNU_LGPLv3",
 	"MIT_License",
 	"Mozilla_Public_License_2.0",
+	"None",
 }
 
 func DownloadLicenses(path string) {

--- a/licenses/manager.go
+++ b/licenses/manager.go
@@ -1,0 +1,22 @@
+package licenses
+
+import "rectx/utilities"
+
+var LICENSES = []string{
+	"Apache_License_2.0",
+	"Boost_Software_License",
+	"GNU_AGPLv3",
+	"GNU_GPL3",
+	"GNU_LGPLv3",
+	"MIT_License",
+	"Mozilla_Public_License_2.0",
+}
+
+func DownloadLicenses(path string) {
+	for _, license := range LICENSES {
+		utilities.DownloadFile(
+			utilities.GetRectxDownloadSource()+"/licenses/"+license,
+			path+license,
+		)
+	}
+}

--- a/licenses/prompt.go
+++ b/licenses/prompt.go
@@ -1,0 +1,33 @@
+package licenses
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Prompt Handles getting the license from a user.
+// Allows for both index and exact string matches when choosing a license.
+// If "None" is selected then prompt will return "None" (You must handle this output if so).
+func Prompt() string {
+	selectedLicense := ""
+
+	LICENSES = append(LICENSES, "None")
+	for i, license := range LICENSES {
+		fmt.Printf("%d. %s\n", i+1, license)
+	}
+	fmt.Print("Chosen license: ")
+	fmt.Scanln(selectedLicense)
+	if index, err := strconv.Atoi(selectedLicense); err == nil {
+		selectedLicense = LICENSES[index-1]
+	} else if selectedLicense == "None" {
+		return selectedLicense
+	} else {
+		for _, license := range LICENSES {
+			if selectedLicense == license {
+				return selectedLicense
+			}
+		}
+	}
+	fmt.Printf("\"%s\" is not a valid license name or number!\n", selectedLicense)
+	return Prompt()
+}

--- a/licenses/prompt.go
+++ b/licenses/prompt.go
@@ -9,17 +9,16 @@ import (
 // Allows for both index and exact string matches when choosing a license.
 // If "None" is selected then prompt will return "None" (You must handle this output if so).
 func Prompt() string {
-	selectedLicense := ""
+	var selectedLicense string
 
-	LICENSES = append(LICENSES, "None")
 	for i, license := range LICENSES {
 		fmt.Printf("%d. %s\n", i+1, license)
 	}
 	fmt.Print("Chosen license: ")
-	fmt.Scanln(selectedLicense)
+	fmt.Scanln(&selectedLicense)
+
 	if index, err := strconv.Atoi(selectedLicense); err == nil {
 		selectedLicense = LICENSES[index-1]
-	} else if selectedLicense == "None" {
 		return selectedLicense
 	} else {
 		for _, license := range LICENSES {

--- a/licenses/prompt.go
+++ b/licenses/prompt.go
@@ -1,8 +1,11 @@
 package licenses
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 )
 
 // Prompt Handles getting the license from a user.
@@ -10,17 +13,21 @@ import (
 // If "None" is selected then prompt will return "None" (You must handle this output if so).
 func Prompt() string {
 	var selectedLicense string
+	in := bufio.NewReader(os.Stdin)
 
 	for i, license := range LICENSES {
-		fmt.Printf("%d. %s\n", i+1, license)
+		fmt.Printf("%d. %s\n", i+1, strings.ReplaceAll(license, "_", " "))
 	}
 	fmt.Print("Chosen license: ")
-	fmt.Scanln(&selectedLicense)
+
+	selectedLicense, _ = in.ReadString('\n')
+	selectedLicense = selectedLicense[0 : len(selectedLicense)-1]
 
 	if index, err := strconv.Atoi(selectedLicense); err == nil {
 		selectedLicense = LICENSES[index-1]
 		return selectedLicense
 	} else {
+		selectedLicense = strings.ReplaceAll(selectedLicense, " ", "_")
 		for _, license := range LICENSES {
 			if selectedLicense == license {
 				return selectedLicense

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 	case "templates":
 		fallthrough
 	case "template":
+		// TODO debug flag not working for template subcommands - Issue should probably be created.
 		handleParseErrorAndHelpFlag(templateCmd, templateCmd.Parse(os.Args[2:]), ShowTemplateHelpMenu)
 		EnsureArguments(3, "template")
 
@@ -71,7 +72,7 @@ func main() {
 		// `rectx template snapshot <path>` generates a .rectx.template file from the information provided in the directory provided.
 		// NOTE: the template name will be taken from the directory name, commands should be held within a file called "commands"
 		case "snapshot":
-			// TODO maybe an exlude flag should be added so people can avoid files named "commands" that have other purposes?
+			// TODO maybe an exclude flag should be added so people can avoid files named "commands" that have other purposes?
 			EnsureArguments(4, "template snapshot")
 			templates.Snapshot(os.Args[3])
 

--- a/metavariables/parser.go
+++ b/metavariables/parser.go
@@ -34,7 +34,6 @@ func (p *Parser) Parse() string {
 				p.index++
 				if p.current() == "%" {
 					buffer += p.current()
-					fmt.Printf("BUFFER EXIT: %s\n", buffer)
 					break
 				}
 			}
@@ -48,7 +47,6 @@ func (p *Parser) Parse() string {
 			// If found, replace with metavariable value
 			if metaContent, found := p.variables[buffer]; found {
 				p.output += metaContent
-				fmt.Printf("Replaced %s with %s\n", buffer, metaContent)
 				p.index++
 			} else {
 				// Otherwise, write buffer to output

--- a/metavariables/parser.go
+++ b/metavariables/parser.go
@@ -1,19 +1,22 @@
 package metavariables
-// I love how this entire package can just be replaced with a strings.Replace() function LMAO
+
+import "fmt"
 
 type Parser struct {
-	content       string
-	output        string
-	index         int
-	metavariables map[string]string
+	content   string
+	output    string
+	index     int
+	variables map[string]string
 }
 
-func NewParser(content string, metavariables map[string]string) *Parser {
+func NewParser(content string, variables map[string]string) *Parser {
+	fmt.Println(variables)
+
 	return &Parser{
-		content:       content,
-		output:        "",
-		index:         0,
-		metavariables: metavariables,
+		content:   content,
+		output:    "",
+		index:     0,
+		variables: variables,
 	}
 }
 
@@ -25,10 +28,15 @@ func (p *Parser) Parse() string {
 			for p.index < len(p.content) {
 				buffer += p.current()
 				if p.current() == "\n" || p.current() == " " ||
-					p.current() == "\t" || p.current() == "%" {
+					p.current() == "\t" {
 					break
 				}
 				p.index++
+				if p.current() == "%" {
+					buffer += p.current()
+					fmt.Printf("BUFFER EXIT: %s\n", buffer)
+					break
+				}
 			}
 
 			if buffer[len(buffer)-1] != '%' {
@@ -37,12 +45,10 @@ func (p *Parser) Parse() string {
 				continue
 			}
 
-			// Lookup %...% in metavariables
-			metacontent, ok := p.metavariables[buffer]
-
 			// If found, replace with metavariable value
-			if ok {
-				p.output = metacontent
+			if metaContent, found := p.variables[buffer]; found {
+				p.output += metaContent
+				fmt.Printf("Replaced %s with %s\n", buffer, metaContent)
 				p.index++
 			} else {
 				// Otherwise, write buffer to output

--- a/metavariables/parser.go
+++ b/metavariables/parser.go
@@ -1,7 +1,5 @@
 package metavariables
 
-import "fmt"
-
 type Parser struct {
 	content   string
 	output    string
@@ -10,8 +8,6 @@ type Parser struct {
 }
 
 func NewParser(content string, variables map[string]string) *Parser {
-	fmt.Println(variables)
-
 	return &Parser{
 		content:   content,
 		output:    "",
@@ -44,7 +40,7 @@ func (p *Parser) Parse() string {
 				continue
 			}
 
-			// If found, replace with metavariable value
+			// If found, replace with meta variable value
 			if metaContent, found := p.variables[buffer]; found {
 				p.output += metaContent
 				p.index++

--- a/project_manager/config/config.go
+++ b/project_manager/config/config.go
@@ -16,10 +16,11 @@ type (
 	}
 
 	ProjectDetailsConfig struct {
-		Name    string
-		Authors []string
-		Version string
-		License string
+		Name     string
+		Authors  []string
+		Version  string
+		License  string
+		Template string
 	}
 
 	BuildConfig struct {
@@ -57,10 +58,11 @@ func CreateDefaultConfig() *ProjectConfig {
 	}
 
 	projectConfig := ProjectDetailsConfig{
-		Name:    "",
-		Authors: nil,
-		Version: "",
-		License: "",
+		Name:     "",
+		Authors:  nil,
+		Version:  "",
+		License:  "",
+		Template: "",
 	}
 
 	config := ProjectConfig{

--- a/project_manager/config/config.go
+++ b/project_manager/config/config.go
@@ -19,6 +19,7 @@ type (
 		Name    string
 		Authors []string
 		Version string
+		License string
 	}
 
 	BuildConfig struct {
@@ -59,6 +60,7 @@ func CreateDefaultConfig() *ProjectConfig {
 		Name:    "",
 		Authors: nil,
 		Version: "",
+		License: "",
 	}
 
 	config := ProjectConfig{

--- a/project_manager/generator.go
+++ b/project_manager/generator.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"rectx/licenses"
 	projectConfig "rectx/project_manager/config"
 	"rectx/templates"
 	"rectx/utilities"
 	"strings"
 )
 
-func CreateNewProject(config *projectConfig.ProjectConfig) {
+func CreateNewProject(config *projectConfig.ProjectConfig, variables map[string]string) {
 	fmt.Print("Generating project... ")
 
 	if file, err := os.Stat(config.Project.Name); err == nil {
@@ -39,6 +40,8 @@ func CreateNewProject(config *projectConfig.ProjectConfig) {
 	} else {
 		utilities.Check(err, true, "Attempt to read template file failed.")
 	}
+
+	licenses.GenerateLicense(config.Project.License, variables)
 
 	parser := templates.NewTemplateParser(string(f))
 	statements := parser.Parse()

--- a/project_manager/generator.go
+++ b/project_manager/generator.go
@@ -8,11 +8,21 @@ import (
 	projectConfig "rectx/project_manager/config"
 	"rectx/templates"
 	"rectx/utilities"
+	"strconv"
 	"strings"
+	"time"
 )
 
-func CreateNewProject(config *projectConfig.ProjectConfig, variables map[string]string) {
+func CreateNewProject(config *projectConfig.ProjectConfig) {
 	fmt.Print("Generating project... ")
+
+	variables := make(map[string]string)
+	variables["%PROJECT_NAME%"] = config.Project.Name
+	variables["%AUTHOR%"] = config.Project.Authors[0]
+	year, month, day := time.Now().Date()
+	variables["%YEAR%"] = strconv.Itoa(year)
+	variables["%MONTH%"] = month.String()
+	variables["%DAY%"] = strconv.Itoa(day)
 
 	if file, err := os.Stat(config.Project.Name); err == nil {
 		tyype := ""

--- a/project_manager/generator.go
+++ b/project_manager/generator.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-func CreateNewProject(config *projectConfig.ProjectConfig, templateName string) {
+func CreateNewProject(config *projectConfig.ProjectConfig) {
 	fmt.Print("Generating project... ")
 
 	if file, err := os.Stat(config.Project.Name); err == nil {
@@ -33,7 +33,7 @@ func CreateNewProject(config *projectConfig.ProjectConfig, templateName string) 
 	}
 	utilities.Check(os.Mkdir(config.Project.Name, 0750), true, "Attempt to create project directory failed... Permission levels may not be sufficient?")
 
-	f, err := os.ReadFile(utilities.GetRectxPath() + "/templates/" + templateName)
+	f, err := os.ReadFile(utilities.GetRectxPath() + "/templates/" + config.Project.Template)
 	if os.IsNotExist(err) {
 		utilities.Check(err, true, "Attempt to read template file failed because it doesn't exist... What?")
 	} else {

--- a/project_manager/generator.go
+++ b/project_manager/generator.go
@@ -41,7 +41,9 @@ func CreateNewProject(config *projectConfig.ProjectConfig, variables map[string]
 		utilities.Check(err, true, "Attempt to read template file failed.")
 	}
 
-	licenses.GenerateLicense(config.Project.License, variables)
+	if config.Project.License != "None" {
+		licenses.GenerateLicense(config.Project.License, variables)
+	}
 
 	parser := templates.NewTemplateParser(string(f))
 	statements := parser.Parse()

--- a/project_manager/new.go
+++ b/project_manager/new.go
@@ -33,7 +33,7 @@ func New() {
 
 	pc.Project.Template = GetTemplate()
 
-	CreateNewProject(pc)
+	CreateNewProject(pc, variables)
 
 	pc.Dump(pc.Project.Name + "/project.rectx")
 }

--- a/project_manager/new.go
+++ b/project_manager/new.go
@@ -5,9 +5,7 @@ import (
 	"rectx/licenses"
 	projectConfig "rectx/project_manager/config"
 	"rectx/templates"
-	"strconv"
 	"strings"
-	"time"
 )
 
 func New() {
@@ -25,15 +23,7 @@ func New() {
 	pc.Project.License = licenses.Prompt()
 	pc.Project.Template = GetTemplate()
 
-	variables := make(map[string]string)
-	variables["%PROJECT_NAME%"] = pc.Project.Name
-	variables["%AUTHOR%"] = pc.Project.Authors[0]
-	year, month, day := time.Now().Date()
-	variables["%YEAR%"] = strconv.Itoa(year)
-	variables["%MONTH%"] = month.String()
-	variables["%DAY%"] = strconv.Itoa(day)
-
-	CreateNewProject(pc, variables)
+	CreateNewProject(pc)
 
 	pc.Dump(pc.Project.Name + "/project.rectx")
 }

--- a/project_manager/new.go
+++ b/project_manager/new.go
@@ -5,6 +5,7 @@ import (
 	"rectx/licenses"
 	projectConfig "rectx/project_manager/config"
 	"rectx/templates"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -28,9 +29,9 @@ func New() {
 	variables["%PROJECT_NAME%"] = pc.Project.Name
 	variables["%AUTHOR%"] = pc.Project.Authors[0]
 	year, month, day := time.Now().Date()
-	variables["%YEAR%"] = string(rune(year))
+	variables["%YEAR%"] = strconv.Itoa(year)
 	variables["%MONTH%"] = month.String()
-	variables["%DAY%"] = string(rune(day))
+	variables["%DAY%"] = strconv.Itoa(day)
 
 	CreateNewProject(pc, variables)
 

--- a/project_manager/new.go
+++ b/project_manager/new.go
@@ -31,10 +31,9 @@ func New() {
 	variables["%MONTH%"] = month.String()
 	variables["%DAY%"] = string(rune(day))
 
-	// TODO store template name in pc?
-	templateName := GetTemplate()
+	pc.Project.Template = GetTemplate()
 
-	CreateNewProject(pc, templateName)
+	CreateNewProject(pc)
 
 	pc.Dump(pc.Project.Name + "/project.rectx")
 }

--- a/project_manager/new.go
+++ b/project_manager/new.go
@@ -22,6 +22,7 @@ func New() {
 
 	pc.Project.Version = GetVersion()
 	pc.Project.License = licenses.Prompt()
+	pc.Project.Template = GetTemplate()
 
 	variables := make(map[string]string)
 	variables["%PROJECT_NAME%"] = pc.Project.Name
@@ -30,8 +31,6 @@ func New() {
 	variables["%YEAR%"] = string(rune(year))
 	variables["%MONTH%"] = month.String()
 	variables["%DAY%"] = string(rune(day))
-
-	pc.Project.Template = GetTemplate()
 
 	CreateNewProject(pc, variables)
 

--- a/project_manager/new.go
+++ b/project_manager/new.go
@@ -2,9 +2,11 @@ package project_manager
 
 import (
 	"fmt"
+	"rectx/licenses"
 	projectConfig "rectx/project_manager/config"
 	"rectx/templates"
 	"strings"
+	"time"
 )
 
 func New() {
@@ -19,7 +21,17 @@ func New() {
 	pc.Project.Authors = append(pc.Project.Authors, author)
 
 	pc.Project.Version = GetVersion()
+	pc.Project.License = licenses.Prompt()
 
+	variables := make(map[string]string)
+	variables["%PROJECT_NAME%"] = pc.Project.Name
+	variables["%AUTHOR%"] = pc.Project.Authors[0]
+	year, month, day := time.Now().Date()
+	variables["%YEAR%"] = string(rune(year))
+	variables["%MONTH%"] = month.String()
+	variables["%DAY%"] = string(rune(day))
+
+	// TODO store template name in pc?
 	templateName := GetTemplate()
 
 	CreateNewProject(pc, templateName)


### PR DESCRIPTION
## Description
This pull request adds LICENSE file generation along with a series of bug fixes to the related systems. LICENSE file generation was planned feature of ReCTx originating from the old Rust-based codebase.

This feature generates a LICENSE file chosen by the user. There are multiple options (including "None"). A file containing license information will be generated along with the other project files.

## Problems solved
- [Added LICENSE file generation](https://github.com/hrszpuk/rectx/commit/140a8b6078862c17314a33d9004923dbc1ddcae6))
- [Fixed infinite prompt bug](https://github.com/hrszpuk/rectx/commit/4099220cf326af20241304147d341bdf26212797)
- [Fixed "None" License bug](https://github.com/hrszpuk/rectx/commit/64c17891eb34dfc1b330e22dbef7fadaa40309de)
- [Fixed LICENSE file generation bug](https://github.com/hrszpuk/rectx/commit/5b5dfe22d0c09466310e8976baf44613ec064e6d)
- [Fixed meta variable replacement bugs](https://github.com/hrszpuk/rectx/commit/8fb75f3d33aa0ef457a74f9b9b274cad3f566ee4)
- [Fixed year/day go rune bug](https://github.com/hrszpuk/rectx/commit/d34dad95da7c3acc01835a5680cfc811602e8d10)

## Related Issues/PR
- Close #56 